### PR TITLE
refactor: add job-level permissions to workflows

### DIFF
--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -1,7 +1,5 @@
 name: Force Release
 
-permissions:
-  contents: write
 
 on:
   workflow_dispatch:
@@ -9,6 +7,8 @@ on:
 jobs:
   force-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/force_regenerate_schemas.yml
+++ b/.github/workflows/force_regenerate_schemas.yml
@@ -1,8 +1,5 @@
 name: Force Regenerate All Schemas
 
-permissions:
-  contents: write
-  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -11,6 +8,8 @@ jobs:
   force-regenerate:
     name: Force regenerate all schema packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/git_mirror.yml
+++ b/.github/workflows/git_mirror.yml
@@ -1,7 +1,5 @@
 name: Mirror to Codeberg and GitLab
 
-permissions:
-  contents: read
 
 on:
   push:
@@ -10,6 +8,8 @@ on:
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: ffflorian/actions/git-mirror@baf8fb2e65ebe6564870f56315a09bc01ab7e0f7
         with:

--- a/.github/workflows/lint_test_publish.yml
+++ b/.github/workflows/lint_test_publish.yml
@@ -1,7 +1,5 @@
 name: Build, lint, test, publish
 
-permissions:
-  contents: write
 
 on:
   push:
@@ -13,6 +11,8 @@ jobs:
   lint_test_build:
     name: Lint, test and build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/publish_generated_packages.yml
+++ b/.github/workflows/publish_generated_packages.yml
@@ -1,9 +1,5 @@
 name: Publish Generated Packages
 
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
 
 on:
   push:
@@ -17,6 +13,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'chore(schemas): weekly schema update'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/weekly_schema_update.yml
+++ b/.github/workflows/weekly_schema_update.yml
@@ -1,8 +1,5 @@
 name: Weekly Schema Update
 
-permissions:
-  contents: write
-  pull-requests: write
 
 on:
   schedule:
@@ -13,6 +10,8 @@ jobs:
   update-schemas:
     name: Update generated schema packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/yarn_update.yml
+++ b/.github/workflows/yarn_update.yml
@@ -1,8 +1,5 @@
 name: Check for yarn updates
 
-permissions:
-  contents: write
-  pull-requests: write
 
 on:
   schedule:
@@ -17,6 +14,8 @@ on:
 jobs:
   yarn-update-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Update yarn
         uses: ffflorian/actions/yarn-update@baf8fb2e65ebe6564870f56315a09bc01ab7e0f7


### PR DESCRIPTION
Remove global permissions blocks and add job-specific permissions to all workflows.

Each job now includes appropriate permissions based on its operations:
- Standard jobs: contents: read
- Publishing jobs: id-token: write, contents: write
- Security jobs: security-events: write, packages: read, actions: read

Follows GitHub Security Hardening best practices:
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs