### PR TITLE
chore: add job-level permissions to workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,8 +19,11 @@ on:
   schedule:
     - cron: '43 20 * * 6'
 
+permissions: {}
 jobs:
   analyze:
+    permissions:
+      contents: read
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
@@ -28,75 +31,3 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: javascript-typescript
-            build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      # Add any setup steps before running the `github/codeql-action/init` action.
-      # This includes steps like installing compilers or runtimes (`actions/setup-node`
-      # or others). This is typically only required for manual builds.
-      # - name: Setup runtime (example)
-      #   uses: actions/setup-example@v1
-
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13
-        with:
-          config-file: ./.github/codeql/codeql-config.yml
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
-
-      # If the analyze step fails for one of the languages you are analyzing with
-      # "We were unable to automatically build your code", modify the matrix above
-      # to set the build mode to "manual" for that language. Then modify this step
-      # to build your code.
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - name: Run manual build steps
-        if: matrix.build-mode == 'manual'
-        shell: bash
-        run: |
-          echo 'If you are using a "manual" build mode for one or more of the' \
-            'languages you are analyzing, replace this with the commands to build' \
-            'your code, for example:'
-          echo '  make bootstrap'
-          echo '  make release'
-          exit 1
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13
-        with:
-          category: '/language:${{matrix.language}}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,8 @@
 #
 name: 'CodeQL Advanced'
 
+permissions: {}
+
 on:
   push:
     branches: ['main']
@@ -19,11 +21,8 @@ on:
   schedule:
     - cron: '43 20 * * 6'
 
-permissions: {}
 jobs:
   analyze:
-    permissions:
-      contents: read
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
@@ -31,3 +30,75 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13
+        with:
+          config-file: ./.github/codeql/codeql-config.yml
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13
+        with:
+          category: '/language:${{matrix.language}}'

--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -1,13 +1,13 @@
 name: Force Release
 
+permissions: {}
 on:
   workflow_dispatch:
 
-permissions: {}
 jobs:
   force-release:
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -1,13 +1,13 @@
 name: Force Release
 
-permissions:
-  contents: write
-
 on:
   workflow_dispatch:
 
+permissions: {}
 jobs:
   force-release:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/force_regenerate_schemas.yml
+++ b/.github/workflows/force_regenerate_schemas.yml
@@ -1,14 +1,13 @@
 name: Force Regenerate All Schemas
 
-permissions:
-  contents: write
-  pull-requests: write
-
 on:
   workflow_dispatch:
 
+permissions: {}
 jobs:
   force-regenerate:
+    permissions:
+      contents: read
     name: Force regenerate all schema packages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/force_regenerate_schemas.yml
+++ b/.github/workflows/force_regenerate_schemas.yml
@@ -1,13 +1,15 @@
 name: Force Regenerate All Schemas
 
+permissions: {}
+
 on:
   workflow_dispatch:
 
-permissions: {}
 jobs:
   force-regenerate:
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     name: Force regenerate all schema packages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/git_mirror.yml
+++ b/.github/workflows/git_mirror.yml
@@ -1,10 +1,11 @@
 name: Mirror to Codeberg and GitLab
 
+permissions: {}
+
 on:
   push:
     branches: [main]
 
-permissions: {}
 jobs:
   mirror:
     permissions:

--- a/.github/workflows/git_mirror.yml
+++ b/.github/workflows/git_mirror.yml
@@ -1,14 +1,14 @@
 name: Mirror to Codeberg and GitLab
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [main]
 
+permissions: {}
 jobs:
   mirror:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: ffflorian/actions/git-mirror@baf8fb2e65ebe6564870f56315a09bc01ab7e0f7

--- a/.github/workflows/lint_test_publish.yml
+++ b/.github/workflows/lint_test_publish.yml
@@ -1,16 +1,17 @@
 name: Build, lint, test, publish
 
+permissions: {}
+
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
-permissions: {}
 jobs:
-  lint_test_build:
+  lint_test_publish:
     permissions:
-      contents: read
+      contents: write
     name: Lint, test and build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint_test_publish.yml
+++ b/.github/workflows/lint_test_publish.yml
@@ -1,16 +1,16 @@
 name: Build, lint, test, publish
 
-permissions:
-  contents: write
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
+permissions: {}
 jobs:
   lint_test_build:
+    permissions:
+      contents: read
     name: Lint, test and build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish_generated_packages.yml
+++ b/.github/workflows/publish_generated_packages.yml
@@ -1,17 +1,15 @@
 name: Publish Generated Packages
 
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
+permissions: {}
 jobs:
   publish_generated_packages:
+    permissions:
+      contents: read
     name: Publish generated packages
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/publish_generated_packages.yml
+++ b/.github/workflows/publish_generated_packages.yml
@@ -1,15 +1,18 @@
 name: Publish Generated Packages
 
+permissions: {}
+
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-permissions: {}
 jobs:
   publish_generated_packages:
     permissions:
-      contents: read
+      id-token: write
+      contents: write
+      pull-requests: write
     name: Publish generated packages
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/weekly_schema_update.yml
+++ b/.github/workflows/weekly_schema_update.yml
@@ -1,15 +1,17 @@
 name: Weekly Schema Update
 
+permissions: {}
+
 on:
   schedule:
     - cron: '0 5 * * 1' # Every Monday at 05:00 AM UTC
   workflow_dispatch:
 
-permissions: {}
 jobs:
   update-schemas:
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     name: Update generated schema packages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/weekly_schema_update.yml
+++ b/.github/workflows/weekly_schema_update.yml
@@ -1,16 +1,15 @@
 name: Weekly Schema Update
 
-permissions:
-  contents: write
-  pull-requests: write
-
 on:
   schedule:
     - cron: '0 5 * * 1' # Every Monday at 05:00 AM UTC
   workflow_dispatch:
 
+permissions: {}
 jobs:
   update-schemas:
+    permissions:
+      contents: read
     name: Update generated schema packages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/yarn_update.yml
+++ b/.github/workflows/yarn_update.yml
@@ -1,9 +1,5 @@
 name: Check for yarn updates
 
-permissions:
-  contents: write
-  pull-requests: write
-
 on:
   schedule:
     - cron: '0 5 1 * *'
@@ -14,8 +10,11 @@ on:
       - '.github/workflows/yarn_update.yml'
   workflow_dispatch:
 
+permissions: {}
 jobs:
   yarn-update-check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Update yarn

--- a/.github/workflows/yarn_update.yml
+++ b/.github/workflows/yarn_update.yml
@@ -1,5 +1,7 @@
 name: Check for yarn updates
 
+permissions: {}
+
 on:
   schedule:
     - cron: '0 5 1 * *'
@@ -10,11 +12,11 @@ on:
       - '.github/workflows/yarn_update.yml'
   workflow_dispatch:
 
-permissions: {}
 jobs:
   yarn-update-check:
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Update yarn


### PR DESCRIPTION
## Summary

This PR moves GitHub Actions workflow permissions from the global workflow level to individual jobs, implementing the principle of least privilege.

### Changes
- Removed global `permissions:` blocks from workflow roots
- Added job-level permissions to each job based on its functionality
- All jobs receive a baseline of `contents: read`
- Jobs performing sensitive operations (publishing, releasing, etc.) receive additional write permissions as needed

### Permissions Added
- **npm publishing jobs**: `id-token: write`, `contents: write`
- **Security/CodeQL analysis**: `security-events: write`, `packages: read`, `actions: read`
- **Release/git operations**: `contents: write`
- **Read-only jobs**: `contents: read` (baseline)

### Benefits
✅ Improved security posture
✅ Follows GitHub Actions best practices
✅ Easier to audit job-specific permissions
✅ Aligns with principle of least privilege