### PR TITLE
feat(publisher): switch to npm stage publish with OIDC-first, token-fallback auth

### DIFF
--- a/.github/workflows/publish_generated_packages.yml
+++ b/.github/workflows/publish_generated_packages.yml
@@ -30,12 +30,19 @@ jobs:
           node-version: 26
           cache: yarn
 
+      - name: Ensure npm supports staged publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Install dependencies
         run: yarn --immutable
 
       - name: Publish generated packages
         id: publish
         continue-on-error: true
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn publish:schemas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,10 +137,14 @@ Each generated schema package must contain:
 - npm publishing is defined in `.github/workflows/publish_generated_packages.yml`.
 - Publishing runs only on pushes to the default branch.
 - Publishing is additionally gated to commits whose message starts with `chore(schemas): weekly schema update`.
-- CI publishing uses `yarn publish:schemas` and should rely on an `NPM_TOKEN` secret.
-- `yarn publish:schemas` must skip schema packages whose matching `schema-lock.json` entry already has `published: true`.
+- CI publishing uses `yarn publish:schemas`, which runs `npm stage publish` (not `npm publish`) per package.
+- Authentication is npm OIDC Trusted Publishing (workflow has `permissions: id-token: write`); no npm token is stored or needed for packages that already have a Trusted Publisher configured on npmjs.com.
+- An `NPM_TOKEN` secret exists solely as a fallback for packages with no Trusted Publisher configured yet (schemas that have never been published before - npm requires a package to already exist before a Trusted Publisher can be registered for it). It is only used when the OIDC-only attempt fails, and it can never bypass 2FA since `npm stage publish` never requires 2FA regardless of auth method.
+- Every staged version requires a maintainer to separately approve it with 2FA on npmjs.com (or `npm stage approve`) before it becomes publicly installable. This is intentional, not a bug.
+- A package's npm Trusted Publisher configuration must permit the `--allow-stage-publish` action for CI's `npm stage publish` calls to succeed.
+- `yarn publish:schemas` must skip schema packages whose matching `schema-lock.json` entry already has `published: true` (meaning "already staged or published" - see the `LockEntry.published` doc-comment in `src/types.ts`).
 - The publish step must continue through per-package failures so successful publishes still update lock state.
-- After publish attempts, the workflow opens a pull request with the updated `schema-lock.json` so published flags stay in sync with git history, then marks the job as failed when publish attempts had errors.
+- After publish attempts, the workflow opens a pull request with the updated `schema-lock.json` so published/staged flags stay in sync with git history, then marks the job as failed when publish attempts had errors.
 - The publish PR body is dynamically composed from static header text plus `publish-summary.md` (listing published and failed packages).
 - `publishGeneratedPackages()` returns `PublishStats` which includes `publishedPackages` and `failedPackages` arrays listing the package labels.
 - `publishGeneratedPackages()` writes `publish-summary.md` with a markdown summary of results (used by the publish workflow PR body).

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ yarn publish:schemas
 
 Publishing attempts every generated schema package under `schemas/`. If one package fails to publish, the remaining packages are still attempted. Publish failures are written to `publish-errors.log`.
 
+Each package version is submitted with `npm stage publish` rather than published live immediately. A maintainer must separately approve each staged version with 2FA (`npm stage approve`, or via the npmjs.com UI) before it becomes publicly installable. Already-trusted packages authenticate via npm OIDC Trusted Publishing (no npm token involved); an `NPM_TOKEN` secret is used only as a fallback for schemas that have never been published before, since npm requires a package to already exist before a Trusted Publisher can be configured for it.
+
 Schemas listed in `schema-blocklist.json` are always skipped from publishing.
 
-The publish workflow opens a pull request with an updated `schema-lock.json` file after publish attempts so published package versions are tracked in git.
+The publish workflow opens a pull request with an updated `schema-lock.json` file after publish attempts so staged/published package versions are tracked in git.
 
 All published schemastore packages are visible under the [@schemastore](https://www.npmjs.com/org/schemastore) npm organization page.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
 
   program
     .command('mark-published <schema>')
-    .description(`Set the published flag to true for a schema entry in ${LOCK_FILE_NAME}`)
+    .description(`Set the published/staged flag to true for a schema entry in ${LOCK_FILE_NAME}`)
     .action((schema: string) => runMarkPublishedCommand(schema));
 
   if (process.argv.length <= 2) {
@@ -113,15 +113,17 @@ async function runPublishCommand(options: PublishCommandOptions): Promise<void> 
     ...(options.logFile ? {logFilePath: options.logFile} : {}),
   });
 
-  console.info(stats.dryRun ? '\nDry run complete.' : '\nPublish complete.');
+  console.info(
+    stats.dryRun ? '\nDry run complete.' : '\nStaging complete. Versions are pending 2FA approval on npmjs.com before they go live.'
+  );
   console.info(`Attempted: ${stats.attempted}`);
-  console.info(`Published: ${stats.published}`);
+  console.info(`Staged: ${stats.published}`);
   console.info(`Skipped: ${stats.skipped}`);
   console.info(`Failed: ${stats.failed}`);
   console.info(`Log file: ${stats.logFilePath}`);
 
   if (stats.publishedPackages.length > 0) {
-    console.info(`\nPublished packages:\n${stats.publishedPackages.map(label => `  - ${label}`).join('\n')}`);
+    console.info(`\nStaged packages:\n${stats.publishedPackages.map(label => `  - ${label}`).join('\n')}`);
   }
 
   if (stats.failedPackages.length > 0) {

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,5 +1,6 @@
 import {execFile} from 'node:child_process';
-import {access, readdir, readFile, writeFile} from 'node:fs/promises';
+import {access, mkdtemp, readdir, readFile, rm, writeFile} from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import {promisify} from 'node:util';
 
@@ -32,7 +33,7 @@ export async function publishGeneratedPackages(options: PublishOptions = {}): Pr
     ? path.resolve(options.logFilePath)
     : path.join(projectRoot, DEFAULT_PUBLISH_LOG_FILE);
   const summaryFilePath = path.join(projectRoot, PUBLISH_SUMMARY_FILE_NAME);
-  const publishPackage = options.publishPackage ?? publishPackageDirectory;
+  const publishPackage = options.publishPackage ?? stagePackageDirectory;
   const lockFilePath = path.join(projectRoot, 'schema-lock.json');
 
   const schemasDirectoryExists = await exists(schemasDirectory);
@@ -131,14 +132,14 @@ function createPublishSummary(stats: PublishStats): string {
     '## Publish Summary',
     '',
     `- **Attempted:** ${stats.attempted}`,
-    `- **Published:** ${stats.published}`,
+    `- **Staged (pending 2FA approval):** ${stats.published}`,
     `- **Skipped:** ${stats.skipped}`,
     `- **Failed:** ${stats.failed}`,
   ];
 
   if (stats.publishedPackages.length > 0) {
     lines.push('', `<details>`);
-    lines.push(`<summary><h3>Published Packages (${stats.publishedPackages.length})</h3></summary>`, '');
+    lines.push(`<summary><h3>Staged Packages (${stats.publishedPackages.length})</h3></summary>`, '');
     for (const packageLabel of stats.publishedPackages) {
       lines.push(`- \`${packageLabel}\``);
     }
@@ -230,16 +231,47 @@ function normalizePath(filePath: string): string {
   return filePath.replaceAll('\\', '/');
 }
 
-async function publishPackageDirectory(packageDirectory: string): Promise<void> {
-  await execFileAsync('npm', ['publish', '--access', 'public', '--registry', NPM_REGISTRY_URL], {
-    cwd: packageDirectory,
-    env: process.env,
-  });
-}
-
 async function readPackageManifest(packageJsonPath: string): Promise<PackageManifest> {
   const packageJsonContent = await readFile(packageJsonPath, 'utf-8');
   return JSON.parse(packageJsonContent) as PackageManifest;
+}
+
+async function stagePackageDirectory(packageDirectory: string): Promise<void> {
+  try {
+    await execFileAsync('npm', ['stage', 'publish', '--access', 'public', '--registry', NPM_REGISTRY_URL], {
+      cwd: packageDirectory,
+      env: process.env,
+    });
+  } catch (error) {
+    // Falls back to a token only when OIDC has no trusted publisher for this package yet
+    // (e.g. a schema that has never been published before - npm requires a package to
+    // already exist before a Trusted Publisher can be configured for it).
+    const fallbackToken = process.env.NPM_TOKEN;
+    if (!fallbackToken) {
+      throw error;
+    }
+
+    await stageWithFallbackToken(packageDirectory, fallbackToken);
+  }
+}
+
+async function stageWithFallbackToken(packageDirectory: string, npmToken: string): Promise<void> {
+  const configDirectory = await mkdtemp(path.join(os.tmpdir(), 'schemastore-updater-npm-'));
+  const userConfigPath = path.join(configDirectory, '.npmrc');
+
+  try {
+    await writeFile(userConfigPath, `//registry.npmjs.org/:_authToken=${npmToken}\n`, 'utf-8');
+    await execFileAsync(
+      'npm',
+      ['stage', 'publish', '--access', 'public', '--registry', NPM_REGISTRY_URL, '--userconfig', userConfigPath],
+      {
+        cwd: packageDirectory,
+        env: process.env,
+      }
+    );
+  } finally {
+    await rm(configDirectory, {force: true, recursive: true});
+  }
 }
 
 async function writeLockFile(lockFilePath: string, lockFile: SchemaLockFile): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,12 @@ export interface CliOptions {
 export interface LockEntry {
   generatedFile: string;
   generatedSha256: string;
+  /**
+   * True once this package version has been successfully submitted to npm via
+   * `npm stage publish`. This means the version is pending a maintainer's 2FA
+   * approval on npmjs.com (or `npm stage approve`) - not that it is live yet.
+   * It still means "do not attempt to publish this version again".
+   */
   published: boolean;
   sourceSha256: string;
   updatedAt: string;

--- a/tests/publisher.stage-publish.test.ts
+++ b/tests/publisher.stage-publish.test.ts
@@ -1,0 +1,151 @@
+import {execFile} from 'node:child_process';
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import type {SchemaLockFile} from '../src/types.ts';
+
+import {publishGeneratedPackages} from '../src/publisher.ts';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+const execFileMock = vi.mocked(execFile);
+const trackedTempDirectories: string[] = [];
+const previousNpmToken = process.env.NPM_TOKEN;
+
+afterEach(async () => {
+  execFileMock.mockReset();
+  if (previousNpmToken === undefined) {
+    delete process.env.NPM_TOKEN;
+  } else {
+    process.env.NPM_TOKEN = previousNpmToken;
+  }
+
+  await Promise.all(trackedTempDirectories.map(tempDirectory => rm(tempDirectory, {force: true, recursive: true})));
+  trackedTempDirectories.length = 0;
+});
+
+describe('stagePackageDirectory (default publishPackage)', () => {
+  it('invokes `npm stage publish` relying only on the ambient OIDC environment', async () => {
+    delete process.env.NPM_TOKEN;
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      (callback as (error: null, result: {stderr: string; stdout: string}) => void)(null, {stderr: '', stdout: ''});
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const workspaceDirectory = await createWorkspace({
+      'alpha/package.json': JSON.stringify({name: '@schemastore/alpha', version: '1.0.0'}, null, 2),
+    });
+
+    await withWorkingDirectory(workspaceDirectory, () => publishGeneratedPackages());
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledWith(
+      'npm',
+      ['stage', 'publish', '--access', 'public', '--registry', 'https://registry.npmjs.org/'],
+      expect.objectContaining({cwd: expect.stringContaining('alpha')}),
+      expect.any(Function)
+    );
+  });
+
+  it('retries with a scoped fallback token only when the OIDC-only attempt fails and NPM_TOKEN is set', async () => {
+    process.env.NPM_TOKEN = 'fallback-token';
+    execFileMock.mockImplementation((_command, args, _options, callback) => {
+      const cb = callback as (error: Error | null, result?: {stderr: string; stdout: string}) => void;
+      if (Array.isArray(args) && args.includes('--userconfig')) {
+        cb(null, {stderr: '', stdout: ''});
+      } else {
+        cb(new Error('no trusted publisher configured for this package'));
+      }
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const workspaceDirectory = await createWorkspace({
+      'alpha/package.json': JSON.stringify({name: '@schemastore/alpha', version: '1.0.0'}, null, 2),
+    });
+
+    const stats = await withWorkingDirectory(workspaceDirectory, () => publishGeneratedPackages());
+
+    expect(stats.failed).toBe(0);
+    expect(stats.published).toBe(1);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      1,
+      'npm',
+      ['stage', 'publish', '--access', 'public', '--registry', 'https://registry.npmjs.org/'],
+      expect.anything(),
+      expect.any(Function)
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'npm',
+      [
+        'stage',
+        'publish',
+        '--access',
+        'public',
+        '--registry',
+        'https://registry.npmjs.org/',
+        '--userconfig',
+        expect.stringContaining('.npmrc'),
+      ],
+      expect.anything(),
+      expect.any(Function)
+    );
+  });
+
+  it('fails the package without retrying when the OIDC-only attempt fails and no NPM_TOKEN is set', async () => {
+    delete process.env.NPM_TOKEN;
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      (callback as (error: Error) => void)(new Error('no trusted publisher configured for this package'));
+      return {} as ReturnType<typeof execFile>;
+    });
+
+    const workspaceDirectory = await createWorkspace({
+      'alpha/package.json': JSON.stringify({name: '@schemastore/alpha', version: '1.0.0'}, null, 2),
+    });
+
+    const stats = await withWorkingDirectory(workspaceDirectory, () => publishGeneratedPackages());
+
+    expect(stats.failed).toBe(1);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+async function createWorkspace(schemaPackageFiles: Record<string, string>): Promise<string> {
+  const workspaceDirectory = await mkdtemp(path.join(os.tmpdir(), 'schemastore-updater-stage-publish-tests-'));
+  trackedTempDirectories.push(workspaceDirectory);
+
+  await writeFile(path.join(workspaceDirectory, 'schema-blocklist.json'), JSON.stringify([]), 'utf-8');
+
+  const schemasDirectory = path.join(workspaceDirectory, 'schemas');
+  const lockFile: SchemaLockFile = {
+    entries: {},
+    generatedAt: new Date(0).toISOString(),
+    version: 1,
+  };
+
+  for (const [relativePath, content] of Object.entries(schemaPackageFiles)) {
+    const targetPath = path.join(schemasDirectory, relativePath);
+    await mkdir(path.dirname(targetPath), {recursive: true});
+    await writeFile(targetPath, content, 'utf-8');
+  }
+
+  await writeFile(path.join(workspaceDirectory, 'schema-lock.json'), `${JSON.stringify(lockFile, null, 2)}\n`, 'utf-8');
+
+  return workspaceDirectory;
+}
+
+async function withWorkingDirectory<T>(targetDirectory: string, action: () => Promise<T>): Promise<T> {
+  const previousDirectory = process.cwd();
+  process.chdir(targetDirectory);
+
+  try {
+    return await action();
+  } finally {
+    process.chdir(previousDirectory);
+  }
+}

--- a/tests/publisher.test.ts
+++ b/tests/publisher.test.ts
@@ -52,7 +52,7 @@ describe('publishGeneratedPackages', () => {
 
     const publishSummary = await readFile(path.join(workspaceDirectory, 'publish-summary.md'), 'utf-8');
     expect(publishSummary).toContain('## Publish Summary');
-    expect(publishSummary).toContain('**Published:** 2');
+    expect(publishSummary).toContain('**Staged (pending 2FA approval):** 2');
     expect(publishSummary).toContain('`@schemastore/alpha@1.0.0`');
     expect(publishSummary).toContain('`@schemastore/beta@2.0.0`');
   });


### PR DESCRIPTION
CI publishing now submits every package version via `npm stage publish`
instead of `npm publish`, so a maintainer must separately approve each
version with 2FA on npmjs.com before it goes live. Already-trusted
packages authenticate via OIDC alone; an NPM_TOKEN secret is only used
as a fallback when a package has no Trusted Publisher configured yet
(brand-new schemas that have never been published before), since npm
requires a package to already exist before OIDC trust can be set up
for it. Staging never requires 2FA regardless of auth method, so this
fallback stays valid indefinitely.