### PR TITLE
fix(publisher): stream npm login output live instead of buffering it

### DIFF
--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,4 +1,4 @@
-import {execFile} from 'node:child_process';
+import {execFile, spawn} from 'node:child_process';
 import {access, mkdtemp, readdir, readFile, rm, writeFile} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -10,6 +10,7 @@ import {isNonPublishableSchemaId, loadNonPublishableSchemaIds} from './non-publi
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_PUBLISH_LOG_FILE = 'publish-errors.log';
+const NPM_REGISTRY_CHECK_TIMEOUT_MS = 10_000;
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/';
 const PUBLISH_SUMMARY_FILE_NAME = 'publish-summary.md';
 
@@ -84,13 +85,28 @@ export async function bootstrapNewPackages(options: BootstrapOptions = {}): Prom
     const packageLabel = formatPackageLabel(packageManifest, schemaName);
     const packageName = packageManifest.name ?? `@schemastore/${schemaName}`;
 
-    if (await checkPackageExists(packageName)) {
-      // Already exists on npm - just a pending new version, not a first-ever
-      // publish. Leave it for the normal staged-publish pipeline to handle.
-      stats.skippedAlreadyExists += 1;
+    process.stdout.write(`🔍 Checking ${packageLabel} on npm ... `);
+
+    let alreadyExists: boolean;
+    try {
+      alreadyExists = await checkPackageExists(packageName);
+    } catch (error) {
+      stats.failed += 1;
+      stats.failedPackages.push(packageLabel);
+      process.stdout.write('failed\n');
+      console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
       continue;
     }
 
+    if (alreadyExists) {
+      // Already exists on npm - just a pending new version, not a first-ever
+      // publish. Leave it for the normal staged-publish pipeline to handle.
+      stats.skippedAlreadyExists += 1;
+      process.stdout.write('already exists\n');
+      continue;
+    }
+
+    process.stdout.write('not found, will bootstrap\n');
     candidates.push({packageDirectory, packageLabel});
   }
 
@@ -320,8 +336,24 @@ async function loadLockFile(lockFilePath: string): Promise<SchemaLockFile> {
 }
 
 async function loginToNpmWithBrowser(): Promise<void> {
-  await execFileAsync('npm', ['login', '--auth-type=web', '--registry', NPM_REGISTRY_URL], {
-    env: process.env,
+  // `execFile` always buffers the child's output for its callback, even when
+  // asked to inherit stdio, so the login URL never reaches the terminal/CI log
+  // while the process is still running - only `spawn` streams it live, which
+  // is required here since a human needs to see and open that URL in time.
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('npm', ['login', '--auth-type=web', '--registry', NPM_REGISTRY_URL], {
+      env: process.env,
+      stdio: 'inherit',
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`npm login exited with code ${code ?? 'null'} (signal ${signal ?? 'none'})`));
+      }
+    });
   });
 }
 
@@ -340,7 +372,9 @@ function normalizePath(filePath: string): string {
 }
 
 async function packageExistsOnNpm(packageName: string): Promise<boolean> {
-  const response = await fetch(`${NPM_REGISTRY_URL}${packageName}`);
+  const response = await fetch(`${NPM_REGISTRY_URL}${packageName}`, {
+    signal: AbortSignal.timeout(NPM_REGISTRY_CHECK_TIMEOUT_MS),
+  });
   return response.ok;
 }
 

--- a/tests/publisher.bootstrap.test.ts
+++ b/tests/publisher.bootstrap.test.ts
@@ -1,4 +1,5 @@
-import {execFile} from 'node:child_process';
+import {execFile, spawn} from 'node:child_process';
+import {EventEmitter} from 'node:events';
 import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -10,9 +11,11 @@ import {bootstrapNewPackages} from '../src/publisher.ts';
 
 vi.mock('node:child_process', () => ({
   execFile: vi.fn(),
+  spawn: vi.fn(),
 }));
 
 const execFileMock = vi.mocked(execFile);
+const spawnMock = vi.mocked(spawn);
 const fetchMock = vi.fn();
 const trackedTempDirectories: string[] = [];
 
@@ -20,6 +23,7 @@ vi.stubGlobal('fetch', fetchMock);
 
 afterEach(async () => {
   execFileMock.mockReset();
+  spawnMock.mockReset();
   fetchMock.mockReset();
   await Promise.all(trackedTempDirectories.map(tempDirectory => rm(tempDirectory, {force: true, recursive: true})));
   trackedTempDirectories.length = 0;
@@ -28,6 +32,11 @@ afterEach(async () => {
 describe('packageExistsOnNpm / loginToNpmWithBrowser / publishNewPackageDirectory (default bootstrap wiring)', () => {
   it('logs in via browser once, then checks the registry and publishes only packages that do not exist yet', async () => {
     fetchMock.mockResolvedValue({ok: false});
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter();
+      queueMicrotask(() => child.emit('exit', 0, null));
+      return child as ReturnType<typeof spawn>;
+    });
     execFileMock.mockImplementation((_command, _args, _options, callback) => {
       (callback as (error: null, result: {stderr: string; stdout: string}) => void)(null, {stderr: '', stdout: ''});
       return {} as ReturnType<typeof execFile>;
@@ -40,22 +49,40 @@ describe('packageExistsOnNpm / loginToNpmWithBrowser / publishNewPackageDirector
     const stats = await withWorkingDirectory(workspaceDirectory, () => bootstrapNewPackages());
 
     expect(stats.bootstrapped).toBe(1);
-    expect(fetchMock).toHaveBeenCalledWith('https://registry.npmjs.org/@schemastore/alpha');
-    expect(execFileMock).toHaveBeenCalledTimes(2);
-    expect(execFileMock).toHaveBeenNthCalledWith(
-      1,
+    expect(fetchMock).toHaveBeenCalledWith('https://registry.npmjs.org/@schemastore/alpha', {
+      signal: expect.any(AbortSignal),
+    });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenCalledWith(
       'npm',
       ['login', '--auth-type=web', '--registry', 'https://registry.npmjs.org/'],
-      expect.anything(),
-      expect.any(Function)
+      expect.objectContaining({stdio: 'inherit'})
     );
-    expect(execFileMock).toHaveBeenNthCalledWith(
-      2,
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledWith(
       'npm',
       ['publish', '--access', 'public', '--registry', 'https://registry.npmjs.org/'],
       expect.objectContaining({cwd: expect.stringContaining('alpha')}),
       expect.any(Function)
     );
+  });
+
+  it('fails the batch without publishing anything when the npm login itself fails', async () => {
+    fetchMock.mockResolvedValue({ok: false});
+    spawnMock.mockImplementation(() => {
+      const child = new EventEmitter();
+      queueMicrotask(() => child.emit('exit', 1, null));
+      return child as ReturnType<typeof spawn>;
+    });
+
+    const workspaceDirectory = await createWorkspace({
+      'alpha/package.json': JSON.stringify({name: '@schemastore/alpha', version: '1.0.0'}, null, 2),
+    });
+
+    await expect(withWorkingDirectory(workspaceDirectory, () => bootstrapNewPackages())).rejects.toThrow(
+      'npm login exited with code 1'
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
   it('skips publishing when the registry already has the package', async () => {

--- a/tests/publisher.test.ts
+++ b/tests/publisher.test.ts
@@ -264,6 +264,37 @@ describe('bootstrapNewPackages', () => {
     expect(lockFile.entries['beta.json']?.published).toBe(true);
   });
 
+  it('continues checking remaining packages when an existence check fails or times out', async () => {
+    const workspaceDirectory = await createWorkspace({
+      'alpha/package.json': JSON.stringify({name: '@schemastore/alpha', version: '1.0.0'}, null, 2),
+      'beta/package.json': JSON.stringify({name: '@schemastore/beta', version: '1.0.0'}, null, 2),
+    });
+    const loginToNpm = vi.fn(async () => undefined);
+
+    const stats = await withWorkingDirectory(workspaceDirectory, () =>
+      bootstrapNewPackages({
+        checkPackageExists: async packageName => {
+          if (packageName === '@schemastore/alpha') {
+            throw new Error('registry request timed out');
+          }
+          return false;
+        },
+        loginToNpm,
+        publishNewPackage: async () => undefined,
+      })
+    );
+
+    expect(stats).toEqual({
+      attempted: 1,
+      bootstrapped: 1,
+      bootstrappedPackages: ['@schemastore/beta@1.0.0'],
+      failed: 1,
+      failedPackages: ['@schemastore/alpha@1.0.0'],
+      skippedAlreadyExists: 0,
+    });
+    expect(loginToNpm).toHaveBeenCalledTimes(1);
+  });
+
   it('skips packages already marked as published in schema-lock.json without logging in', async () => {
     const workspaceDirectory = await createWorkspace(
       {


### PR DESCRIPTION
## Summary
- Root cause of the bootstrap step appearing stuck on its first real run (no login URL ever showed up in the job log, even after several minutes): `execFile` always buffers a child process's stdout/stderr internally for its callback - even when told to inherit stdio - so nothing streams to the parent process (and therefore the GitHub Actions log) until the child exits. Since `npm login --auth-type=web` blocks/polls waiting for browser approval, its "Login at: ..." URL was being generated the whole time but could never actually reach the log.
- Reproduced and confirmed directly against the real npm CLI in a sandbox before fixing: `execFile` with `stdio: 'inherit'` shows nothing at all; `spawn` with `stdio: 'inherit'` streams the URL immediately. `loginToNpmWithBrowser` now uses `spawn` instead of `execFile`.
- Also adds a 10-second timeout (`AbortSignal.timeout`) to each per-package registry existence check, and prints progress for each one during the pre-login scan phase - Node's native `fetch` has no default timeout, so a single slow/hung check could previously stall the whole step silently with zero visible output.
- A failed existence check for one package no longer aborts the whole batch - it's now recorded as a failure for that package and the scan continues.

## Test plan
- [x] `yarn check`
- [x] `yarn lint`
- [x] `yarn test` (29/29 passing, including new coverage for the `spawn`-based login call, a failed-login-aborts-the-batch case, and a failed/timed-out existence check no longer blocking remaining packages)
- [x] Reproduced the exact "no output" behavior locally with `execFile` + `stdio: 'inherit'`, and confirmed `spawn` + `stdio: 'inherit'` correctly streams the login URL, before applying the fix
- [ ] First real dispatch run against the 6 currently-unbootstrapped packages (`aih-org-policy`, `heloisa-marketplace`, `kind-cluster`, `madge`, `okf-0.1`, `s3-bucket-cors`) to confirm the login URL now actually appears in the job log

---
_Generated by [Claude Code](https://claude.ai/code/session_014spTYaGEmaysF37Z5i2y2j)_