### PR TITLE
chore(publisher): surface the doneUrl response body on OTP poll failures

### DIFF
--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -390,15 +390,20 @@ async function pollForWebAuthToken(doneUrl: string): Promise<string> {
   const deadline = Date.now() + NPM_WEB_AUTH_POLL_TIMEOUT_MS;
 
   while (Date.now() < deadline) {
+    // npm-profile's own webAuthCheckLogin (the code this poll loop mirrors)
+    // reads the response body unconditionally, before branching on status -
+    // matching that here so a non-200/202 status still surfaces whatever
+    // diagnostic the registry sent, instead of just a bare status code.
     const response = await fetch(doneUrl, {headers: {accept: 'application/json'}});
+    const body: unknown = await response.json().catch(() => undefined);
 
     if (response.status === NPM_WEB_AUTH_STATUS_DONE) {
-      const body = (await response.json()) as {token?: string};
-      if (!body.token) {
-        throw new Error('npm one-time-password approval completed but no token was returned');
+      const token = (body as {token?: string} | undefined)?.token;
+      if (!token) {
+        throw new Error(`npm one-time-password approval completed but no token was returned: ${JSON.stringify(body)}`);
       }
 
-      return body.token;
+      return token;
     }
 
     if (response.status === NPM_WEB_AUTH_STATUS_PENDING) {
@@ -408,7 +413,7 @@ async function pollForWebAuthToken(doneUrl: string): Promise<string> {
       continue;
     }
 
-    throw new Error(`npm one-time-password check failed with status ${response.status}`);
+    throw new Error(`npm one-time-password check failed with status ${response.status}: ${JSON.stringify(body)}`);
   }
 
   throw new Error('Timed out waiting for npm one-time-password approval');

--- a/tests/publisher.bootstrap.test.ts
+++ b/tests/publisher.bootstrap.test.ts
@@ -99,7 +99,7 @@ describe('packageExistsOnNpm / loginToNpmWithBrowser / publishNewPackageDirector
     fetchMock.mockImplementation(async (url: string) => {
       if (url.includes('/-/v1/done')) {
         if (fetchMock.mock.calls.filter(call => (call[0] as string).includes('/-/v1/done')).length === 1) {
-          return {headers: new Headers({'retry-after': '0'}), status: 202};
+          return {headers: new Headers({'retry-after': '0'}), json: async () => ({}), status: 202};
         }
 
         return {json: async () => ({token: 'freshly-approved-token'}), status: 200};


### PR DESCRIPTION
## Summary
- Confirmed against the real run (#1579's fix): the OTP-recovery flow triggers correctly - the auth URL prints as expected (`🔐 This publish needs a one-time password...`). But polling `doneUrl` got an immediate `404` instead of the expected `202` (pending) or `200` (done), meaning the poll request doesn't fully match what npm's own CLI sends internally in some way not yet visible from the outside.
- npm-profile's own `webAuthCheckLogin` (the code this poll loop mirrors) reads the response body unconditionally before branching on status. Do the same here, so a non-200/202 status surfaces the registry's actual error body instead of just a bare status code - this is a diagnostic improvement to get a real answer on the next attempt rather than another guess.

## Test plan
- [x] `yarn check`
- [x] `yarn lint`
- [x] `yarn test` (31/31 passing, updated the existing 202-response test mock to include a `.json()` method now that it's called unconditionally)
- [ ] Another real dispatch run to see the actual response body from the 404 and diagnose the real cause

---
_Generated by [Claude Code](https://claude.ai/code/session_014spTYaGEmaysF37Z5i2y2j)_