### PR TITLE
ci: don't let a bootstrap failure skip the rest of the publish job

### DIFF
--- a/.github/workflows/publish_generated_packages.yml
+++ b/.github/workflows/publish_generated_packages.yml
@@ -51,7 +51,9 @@ jobs:
         run: yarn --immutable
 
       - name: Bootstrap brand-new packages via npm browser login
+        id: bootstrap
         if: github.event_name == 'workflow_dispatch' && inputs.bootstrap_new_packages == true
+        continue-on-error: true
         timeout-minutes: 15
         run: yarn bootstrap:new-packages
 
@@ -91,7 +93,7 @@ jobs:
           body-path: pr-body.md
 
       - name: Fail workflow when publishing failed
-        if: steps.publish.outcome == 'failure'
+        if: steps.publish.outcome == 'failure' || steps.bootstrap.outcome == 'failure'
         run: exit 1
 
       - name: Upload publish log


### PR DESCRIPTION
## Summary
- Found while investigating the OTP polling issue (#1580): the bootstrap step had no `continue-on-error`, so when it fails, GitHub Actions skips every subsequent step by default - including the normal staged-publish step for all ~833 other, already-trusted packages. Confirmed in a real run: `Bootstrap brand-new packages via npm browser login` failed, and `Publish generated packages` was skipped entirely as a result, meaning nothing got staged that run even for unrelated packages.
- Adds `continue-on-error: true` and an `id: bootstrap` to that step, and extends the final `Fail workflow when publishing failed` gate to also check `steps.bootstrap.outcome`, matching how the main publish step is already handled.

This is independent of the still-unresolved OTP `doneUrl` 404 issue - it just ensures a bootstrap failure (whatever its cause) no longer blocks the rest of the pipeline.

## Test plan
- [x] `yarn check`
- [x] `yarn lint`
- [x] `yarn test` (31/31 passing - workflow-only change, no code touched)
- [x] Workflow YAML validated for syntax

---
_Generated by [Claude Code](https://claude.ai/code/session_014spTYaGEmaysF37Z5i2y2j)_