### PR TITLE
fix(publisher): authenticate the OTP doneUrl poll as the logged-in npm session

### DIFF
--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -318,6 +318,24 @@ function formatPublishError(packageLabel: string, error: unknown): string {
   return `[${new Date().toISOString()}] ${packageLabel}\n${errorMessage}`;
 }
 
+// The doneUrl check for an EOTP challenge returned a bare 404 with no other
+// diagnostic when polled anonymously. Best remaining theory: it needs to be
+// authenticated as the identity that's currently logged in (the session
+// `npm login --auth-type=web` just cached), not an anonymous request.
+async function getCurrentNpmAuthToken(): Promise<string | undefined> {
+  try {
+    // `npm config get //registry.npmjs.org/:_authToken` refuses to return this
+    // value at all ("this option is protected, and can not be retrieved in
+    // this way"), so read the userconfig file `npm login` wrote it to directly.
+    const {stdout: userConfigPath} = await execFileAsync('npm', ['config', 'get', 'userconfig']);
+    const userConfigContent = await readFile(userConfigPath.trim(), 'utf-8');
+    const tokenMatch = /^\/\/registry\.npmjs\.org\/:_authToken=(\S+)$/m.exec(userConfigContent);
+    return tokenMatch?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
 async function loadLockFile(lockFilePath: string): Promise<SchemaLockFile> {
   if (!(await exists(lockFilePath))) {
     return {
@@ -387,6 +405,12 @@ function parseWebAuthUrls(npmStderr: string): {authUrl: string; doneUrl: string}
 }
 
 async function pollForWebAuthToken(doneUrl: string): Promise<string> {
+  const authToken = await getCurrentNpmAuthToken();
+  const headers: Record<string, string> = {accept: 'application/json'};
+  if (authToken) {
+    headers.authorization = `Bearer ${authToken}`;
+  }
+
   const deadline = Date.now() + NPM_WEB_AUTH_POLL_TIMEOUT_MS;
 
   while (Date.now() < deadline) {
@@ -394,7 +418,7 @@ async function pollForWebAuthToken(doneUrl: string): Promise<string> {
     // reads the response body unconditionally, before branching on status -
     // matching that here so a non-200/202 status still surfaces whatever
     // diagnostic the registry sent, instead of just a bare status code.
-    const response = await fetch(doneUrl, {headers: {accept: 'application/json'}});
+    const response = await fetch(doneUrl, {headers});
     const body: unknown = await response.json().catch(() => undefined);
 
     if (response.status === NPM_WEB_AUTH_STATUS_DONE) {

--- a/tests/publisher.bootstrap.test.ts
+++ b/tests/publisher.bootstrap.test.ts
@@ -85,7 +85,7 @@ describe('packageExistsOnNpm / loginToNpmWithBrowser / publishNewPackageDirector
     expect(execFileMock).not.toHaveBeenCalled();
   });
 
-  it('recovers from a one-time-password challenge by polling doneUrl and retrying with the resulting token', async () => {
+  it('recovers from a one-time-password challenge by polling doneUrl (authenticated as the logged-in session) and retrying with the resulting token', async () => {
     const eotpStderr = [
       'npm error code EOTP',
       'npm error This operation requires a one-time password.',
@@ -96,8 +96,15 @@ describe('packageExistsOnNpm / loginToNpmWithBrowser / publishNewPackageDirector
       'npm error   https://registry.npmjs.org/-/v1/done?authId=test-auth-id',
     ].join('\n');
 
-    fetchMock.mockImplementation(async (url: string) => {
+    const npmrcDirectory = await mkdtemp(path.join(os.tmpdir(), 'schemastore-updater-npmrc-'));
+    trackedTempDirectories.push(npmrcDirectory);
+    const npmrcPath = path.join(npmrcDirectory, '.npmrc');
+    await writeFile(npmrcPath, '//registry.npmjs.org/:_authToken=current-session-token\n', 'utf-8');
+
+    fetchMock.mockImplementation(async (url: string, init?: {headers?: Record<string, string>}) => {
       if (url.includes('/-/v1/done')) {
+        expect(init?.headers?.authorization).toBe('Bearer current-session-token');
+
         if (fetchMock.mock.calls.filter(call => (call[0] as string).includes('/-/v1/done')).length === 1) {
           return {headers: new Headers({'retry-after': '0'}), json: async () => ({}), status: 202};
         }
@@ -108,8 +115,19 @@ describe('packageExistsOnNpm / loginToNpmWithBrowser / publishNewPackageDirector
       return {ok: false};
     });
     mockSpawnSequence([{code: 0}, {code: 1, stderr: eotpStderr}]);
-    execFileMock.mockImplementation((_command, _args, _options, callback) => {
-      (callback as (error: null, result: {stderr: string; stdout: string}) => void)(null, {stderr: '', stdout: ''});
+    execFileMock.mockImplementation((_command, args, ...rest) => {
+      // `execFileAsync('npm', [...])` (no options) puts the callback in the 3rd
+      // slot, while calls that pass an options object put it in the 4th - grab
+      // whichever trailing argument is actually a function instead of assuming
+      // a fixed position.
+      const cb = rest.find((argument): argument is (error: null, result: {stderr: string; stdout: string}) => void =>
+        typeof argument === 'function'
+      );
+      if (Array.isArray(args) && args.join(' ') === 'config get userconfig') {
+        cb?.(null, {stderr: '', stdout: npmrcPath});
+      } else {
+        cb?.(null, {stderr: '', stdout: ''});
+      }
       return {} as ReturnType<typeof execFile>;
     });
 
@@ -120,7 +138,8 @@ describe('packageExistsOnNpm / loginToNpmWithBrowser / publishNewPackageDirector
     const stats = await withWorkingDirectory(workspaceDirectory, () => bootstrapNewPackages());
 
     expect(stats).toMatchObject({bootstrapped: 1, failed: 0});
-    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    expect(execFileMock).toHaveBeenCalledWith('npm', ['config', 'get', 'userconfig'], expect.any(Function));
     expect(execFileMock).toHaveBeenCalledWith(
       'npm',
       [


### PR DESCRIPTION
## Summary
- The `doneUrl` poll for an npm publish OTP (EOTP) challenge (added in #1579, diagnostics improved in #1580) was returning a bare `404` with a generic `{"message":"not found"}` body, even after the diagnostic improvements confirmed there was no further detail in the response itself.
- New theory, since npm's registry may not treat an anonymous poll request as the legitimate holder of that OTP challenge: authenticate the poll as the session `npm login --auth-type=web` already established, by reading the token it cached and sending it as a `Bearer` token.
- `npm config get //registry.npmjs.org/:_authToken` is deliberately blocked by npm itself ("this option is protected, and can not be retrieved in this way"), confirmed via direct testing, so the token is instead read by resolving the userconfig file path (`npm config get userconfig`, which is not protected) and parsing the `_authToken` line out of it directly.

**This is still speculative** - it cannot be fully verified without a real npm 2FA-enabled account completing an actual EOTP flow, which isn't available in this sandbox. If this doesn't resolve the `404`, the recommended fallback is manually bootstrapping the handful of brand-new packages locally (`npm login` + `npm publish` interactively, where the OTP prompt happens in a real terminal and sidesteps polling entirely).

## Test plan
- [x] `yarn check`
- [x] `yarn lint`
- [x] `yarn test` (31/31 passing, including a rewritten OTP-recovery test asserting the `Authorization: Bearer <token>` header is sent on the poll request)


---
_Generated by [Claude Code](https://claude.ai/code/session_014spTYaGEmaysF37Z5i2y2j)_